### PR TITLE
Send tags along in the cloudsearch request.

### DIFF
--- a/src/main/java/org/cru/aemscraper/Main.java
+++ b/src/main/java/org/cru/aemscraper/Main.java
@@ -159,7 +159,8 @@ public class Main {
             .withPublishedDate(getDateProperty(pageEntity, "cq:lastModified"))
             .withUrl(pageUrl)
             .withTemplate(getTemplate(pageEntity))
-            .shouldExcludeFromSearch(getBooleanProperty(pageEntity, "excludeFromSearch"));
+            .shouldExcludeFromSearch(getBooleanProperty(pageEntity, "excludeFromSearch"))
+            .withTags(getTags(pageEntity.getProperties().entrySet()));
 
         if (runMode == RunMode.CLOUDSEARCH) {
             pageData = pageData.withImageUrl(getImageUrl(pageEntity, pageUrl));

--- a/src/main/java/org/cru/aemscraper/model/CloudSearchDocument.java
+++ b/src/main/java/org/cru/aemscraper/model/CloudSearchDocument.java
@@ -27,7 +27,7 @@ public abstract class CloudSearchDocument {
     }
 
     private String id;
-    private Map<String, String> fields;
+    private Map<String, Object> fields;
 
     public abstract String getType();
 
@@ -39,11 +39,11 @@ public abstract class CloudSearchDocument {
         this.id = id;
     }
 
-    public Map<String, String> getFields() {
+    public Map<String, Object> getFields() {
         return fields;
     }
 
-    public void setFields(final Map<String, String> fields) {
+    public void setFields(final Map<String, Object> fields) {
         this.fields = fields;
     }
 }

--- a/src/main/java/org/cru/aemscraper/service/impl/JsonFileBuilderServiceImpl.java
+++ b/src/main/java/org/cru/aemscraper/service/impl/JsonFileBuilderServiceImpl.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,6 +51,8 @@ public class JsonFileBuilderServiceImpl implements JsonFileBuilderService {
         "CruOrgApp/components/page/editable/videoplayer-page",
         "JesusFilmApp/components/page/blogpost"
     );
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void buildJsonFiles(final Set<PageData> pageData, final CloudSearchDocument.Type type) {
@@ -87,7 +88,6 @@ public class JsonFileBuilderServiceImpl implements JsonFileBuilderService {
             File file = buildFile(fileIndex);
             try (BufferedWriter bufferedWriter = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
                 bufferedWriter.write(START_ARRAY);
-                ObjectMapper objectMapper = new ObjectMapper();
                 for (int i = dataIndex; i < pageData.size(); i++) {
                     PageData data = pageData.get(i);
                     if (Strings.isNullOrEmpty(data.getUrl())) {
@@ -177,19 +177,19 @@ public class JsonFileBuilderServiceImpl implements JsonFileBuilderService {
             + END_ARRAY.getBytes(StandardCharsets.UTF_8).length < FIVE_MB;
     }
 
-    private Map<String, String> buildFieldsFromData(final PageData data) {
-        Map<String, String> fields = new HashMap<>();
+    private Map<String, Object> buildFieldsFromData(final PageData data) {
+        Map<String, Object> fields = new HashMap<>();
         if (data.getTags() != null) {
-            fields.put("tags", Arrays.toString(data.getTags().toArray()));
+            fields.put("tags", data.getTags());
         }
         if (data.getTitle() != null) {
             fields.put("title", data.getTitle());
         }
         if (data.getDescription() != null) {
             fields.put("description", data.getDescription());
-            fields.put("has_description", "1");
+            fields.put("has_description", 1);
         } else {
-            fields.put("has_description", "0");
+            fields.put("has_description", 0);
         }
         if (data.getImageUrl() != null) {
             fields.put("image_url", data.getImageUrl());

--- a/src/test/java/org/cru/aemscraper/MainTest.java
+++ b/src/test/java/org/cru/aemscraper/MainTest.java
@@ -43,6 +43,7 @@ public class MainTest {
 
         String score = Main.getContentScore(page);
         assertThat(score, is(equalTo("6")));
+
     }
 
     @Test

--- a/src/test/java/org/cru/aemscraper/service/impl/JsonFileBuilderServiceImplTest.java
+++ b/src/test/java/org/cru/aemscraper/service/impl/JsonFileBuilderServiceImplTest.java
@@ -41,8 +41,8 @@ public class JsonFileBuilderServiceImplTest {
         assertThat(onlyData.getType(), is(equalTo("add")));
         assertThat(onlyData.getId(), is(equalTo(pageData.getUrl())));
 
-        Map<String, String> fields = onlyData.getFields();
-        assertThat(fields.get("tags"), is(equalTo(Arrays.toString(pageData.getTags().toArray()))));
+        Map<String, Object> fields = onlyData.getFields();
+        assertThat(fields.get("tags"), is(equalTo(pageData.getTags())));
         assertThat(fields.get("title"), is(equalTo(pageData.getTitle())));
         assertThat(fields.get("description"), is(equalTo(pageData.getDescription())));
         assertThat(fields.get("image_url"), is(equalTo(pageData.getImageUrl())));
@@ -83,9 +83,9 @@ public class JsonFileBuilderServiceImplTest {
             CloudSearchAddDocument document = readData.next();
             assertThat(document.getType(), is(equalTo("add")));
 
-            Map<String, String> fields = document.getFields();
+            Map<String, Object> fields = document.getFields();
             if (document.getId().equals(url1)) {
-                assertThat(fields.get("tags"), is(equalTo(Arrays.toString(tags.toArray()))));
+                assertThat(fields.get("tags"), is(equalTo(tags)));
             } else if (document.getId().equals(url2)) {
                 assertThat(fields.get("tags"), is(nullValue()));
             }


### PR DESCRIPTION
This also changes the `has_description` to an int since the new map type can handle it, and that is what the actual field is in CloudSearch.