### PR TITLE
AEM-228 - add path literal

### DIFF
--- a/src/main/java/org/cru/aemscraper/service/impl/JsonCloudSearchFileBuilderServiceImpl.java
+++ b/src/main/java/org/cru/aemscraper/service/impl/JsonCloudSearchFileBuilderServiceImpl.java
@@ -176,6 +176,7 @@ public class JsonCloudSearchFileBuilderServiceImpl implements JsonCloudSearchFil
             fields.put("published_date", data.getPublishedDate());
         }
         fields.put("path", data.getUrl());
+        fields.put("path_literal", data.getUrl());
         return fields;
     }
 }

--- a/src/test/java/org/cru/aemscraper/service/impl/JsonCloudSearchFileBuilderServiceImplTest.java
+++ b/src/test/java/org/cru/aemscraper/service/impl/JsonCloudSearchFileBuilderServiceImplTest.java
@@ -47,6 +47,7 @@ public class JsonCloudSearchFileBuilderServiceImplTest {
         assertThat(fields.get("image_url"), is(equalTo(pageData.getImageUrl())));
         assertThat(fields.get("published_date"), is(equalTo(pageData.getPublishedDate())));
         assertThat(fields.get("path"), is(equalTo(pageData.getUrl())));
+        assertThat(fields.get("path_literal"), is(equalTo(pageData.getUrl())));
     }
 
     @Test


### PR DESCRIPTION
This allows us to do a mass scrape of content using the `path_literal` needed for updates to the cru.org search.